### PR TITLE
Fix stability and security problem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -114,7 +114,7 @@
                 <plugin>
                     <groupId>org.glassfish.copyright</groupId>
                     <artifactId>glassfish-copyright-maven-plugin</artifactId>
-                    <version>1.50</version>
+                    <version>2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/src/main/java/com/sun/xml/messaging/saaj/soap/EnvelopeFactory.java
+++ b/src/main/java/com/sun/xml/messaging/saaj/soap/EnvelopeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2014 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -137,13 +137,14 @@ public class EnvelopeFactory {
     private static Envelope parseEnvelopeSax(Source src, SOAPPartImpl soapPart)
             throws SOAPException {
     	SAXParser saxParser = null;
-    	try {
+	    ParserPool underlyingParserPool = parserPool.get();
+	    try {
     		// Insert SAX filter to disallow Document Type Declarations since
     		// they are not legal in SOAP
 
     		if (src instanceof StreamSource) {
     			try {
-    				saxParser = parserPool.get().get();
+    				saxParser = underlyingParserPool.get();
     			} catch (Exception e) {
     				log.severe("SAAJ0601.util.newSAXParser.exception");
     				throw new SOAPExceptionImpl(
@@ -186,7 +187,7 @@ public class EnvelopeFactory {
     	} finally {
     		//no matter what condition occurs, always return the parser to the pool
             if (saxParser != null) {
-                parserPool.get().returnParser(saxParser);
+                underlyingParserPool.returnParser(saxParser);
             }
         }
     }

--- a/src/main/java/com/sun/xml/messaging/saaj/soap/EnvelopeFactory.java
+++ b/src/main/java/com/sun/xml/messaging/saaj/soap/EnvelopeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/src/main/java/com/sun/xml/messaging/saaj/soap/MessageImpl.java
+++ b/src/main/java/com/sun/xml/messaging/saaj/soap/MessageImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -32,8 +32,6 @@ import com.sun.xml.messaging.saaj.SOAPExceptionImpl;
 import com.sun.xml.messaging.saaj.soap.impl.EnvelopeImpl;
 import com.sun.xml.messaging.saaj.util.*;
 import org.jvnet.mimepull.MIMEPart;
-
-import static java.lang.String.format;
 
 /**
  * The message implementation for SOAP messages with
@@ -508,7 +506,7 @@ public abstract class MessageImpl
                             soapMessagePart =
                                     bmMultipart.getNextPart(stream, bndbytes, sin);
                             if (soapBodyPartSizeLimit != null && soapMessagePart.getSize() > soapBodyPartSizeLimit) {
-                                throw new SOAPExceptionImpl(format("SOAP body part of size %s exceeded size limitation: %s", soapMessagePart.getSize(), soapBodyPartSizeLimit));
+                                throw new SOAPExceptionImpl("SOAP body part of size " + soapMessagePart.getSize() + " exceeded size limitation: " + soapBodyPartSizeLimit);
                             }
                             bmMultipart.removeBodyPart(soapMessagePart);
                         } else {

--- a/src/main/java/com/sun/xml/messaging/saaj/soap/MessageImpl.java
+++ b/src/main/java/com/sun/xml/messaging/saaj/soap/MessageImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2014 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -32,6 +32,8 @@ import com.sun.xml.messaging.saaj.SOAPExceptionImpl;
 import com.sun.xml.messaging.saaj.soap.impl.EnvelopeImpl;
 import com.sun.xml.messaging.saaj.util.*;
 import org.jvnet.mimepull.MIMEPart;
+
+import static java.lang.String.format;
 
 /**
  * The message implementation for SOAP messages with
@@ -104,6 +106,10 @@ public abstract class MessageImpl
     private static boolean switchOffLazyAttachment = false;
     private static boolean useMimePull = false;
 
+    private static Integer soapBodyPartSizeLimit;
+
+    public static final String SAAJ_MIME_SOAP_BODY_PART_SIZE_LIMIT = "saaj.mime.soapBodyPartSizeLimit";
+
     static {
             String s = SAAJUtil.getSystemProperty("saaj.mime.optimization");
             if ((s != null) && s.equals("false")) {
@@ -114,6 +120,8 @@ public abstract class MessageImpl
                 switchOffLazyAttachment = true;
             }
             useMimePull = SAAJUtil.getSystemBoolean("saaj.use.mimepull");
+
+            soapBodyPartSizeLimit = SAAJUtil.getSystemInteger(SAAJ_MIME_SOAP_BODY_PART_SIZE_LIMIT);
       
     }
 
@@ -499,6 +507,9 @@ public abstract class MessageImpl
                         if (startParam == null) {
                             soapMessagePart =
                                     bmMultipart.getNextPart(stream, bndbytes, sin);
+                            if (soapBodyPartSizeLimit != null && soapMessagePart.getSize() > soapBodyPartSizeLimit) {
+                                throw new SOAPExceptionImpl(format("SOAP body part of size %s exceeded size limitation: %s", soapMessagePart.getSize(), soapBodyPartSizeLimit));
+                            }
                             bmMultipart.removeBodyPart(soapMessagePart);
                         } else {
                             MimeBodyPart bp = null;

--- a/src/main/java/com/sun/xml/messaging/saaj/util/JAXMStreamSource.java
+++ b/src/main/java/com/sun/xml/messaging/saaj/util/JAXMStreamSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2014 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -14,18 +14,26 @@ import java.io.*;
 
 import javax.xml.transform.stream.StreamSource;
 
+import static com.sun.xml.messaging.saaj.soap.MessageImpl.SAAJ_MIME_SOAP_BODY_PART_SIZE_LIMIT;
+import static java.lang.String.format;
+
 
 /**
  *
  * @author Anil Vijendran
  */
 public class JAXMStreamSource extends StreamSource {
+
+    private static final Integer soapBodyPartSizeLimit;
+
     InputStream in;
     Reader reader;
     private static final boolean lazyContentLength;
     static {
         lazyContentLength = SAAJUtil.getSystemBoolean("saaj.lazy.contentlength");
+        soapBodyPartSizeLimit = SAAJUtil.getSystemInteger(SAAJ_MIME_SOAP_BODY_PART_SIZE_LIMIT);
     }
+
     public JAXMStreamSource(InputStream is) throws IOException {
         if (lazyContentLength) {
             in = is;
@@ -36,7 +44,11 @@ public class JAXMStreamSource extends StreamSource {
             try {
                 bout = new ByteOutputStream();
                 bout.write(is);
-                this.in = bout.newInputStream();
+                ByteInputStream byteInputStream = bout.newInputStream();
+                if (soapBodyPartSizeLimit != null && byteInputStream.getCount() > soapBodyPartSizeLimit) {
+                    throw new IOException(format("SOAP body part of size %s exceeded size limitation: %s", byteInputStream.getCount(), soapBodyPartSizeLimit));
+                }
+                this.in = byteInputStream;
             } finally {
                 if (bout != null)
                     bout.close();

--- a/src/main/java/com/sun/xml/messaging/saaj/util/JAXMStreamSource.java
+++ b/src/main/java/com/sun/xml/messaging/saaj/util/JAXMStreamSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/src/main/java/com/sun/xml/messaging/saaj/util/JAXMStreamSource.java
+++ b/src/main/java/com/sun/xml/messaging/saaj/util/JAXMStreamSource.java
@@ -15,7 +15,6 @@ import java.io.*;
 import javax.xml.transform.stream.StreamSource;
 
 import static com.sun.xml.messaging.saaj.soap.MessageImpl.SAAJ_MIME_SOAP_BODY_PART_SIZE_LIMIT;
-import static java.lang.String.format;
 
 
 /**
@@ -46,7 +45,7 @@ public class JAXMStreamSource extends StreamSource {
                 bout.write(is);
                 ByteInputStream byteInputStream = bout.newInputStream();
                 if (soapBodyPartSizeLimit != null && byteInputStream.getCount() > soapBodyPartSizeLimit) {
-                    throw new IOException(format("SOAP body part of size %s exceeded size limitation: %s", byteInputStream.getCount(), soapBodyPartSizeLimit));
+                    throw new IOException("SOAP body part of size " + byteInputStream.getCount() + " exceeded size limitation: " + soapBodyPartSizeLimit);
                 }
                 this.in = byteInputStream;
             } finally {
@@ -65,10 +64,10 @@ public class JAXMStreamSource extends StreamSource {
         CharArrayWriter cout = new CharArrayWriter();
         char[] temp = new char[1024];
         int len;
-                                                                                
+
         while (-1 != (len = rdr.read(temp)))
             cout.write(temp, 0, len);
-                                                                                
+
         this.reader = new CharArrayReader(cout.toCharArray(), 0, cout.size());
     }
 
@@ -76,7 +75,7 @@ public class JAXMStreamSource extends StreamSource {
     public InputStream getInputStream() {
 	return in;
     }
-    
+
     @Override
     public Reader getReader() {
 	return reader;

--- a/src/main/java/com/sun/xml/messaging/saaj/util/SAAJUtil.java
+++ b/src/main/java/com/sun/xml/messaging/saaj/util/SAAJUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2014 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -25,6 +25,14 @@ public final class SAAJUtil {
             return Boolean.getBoolean(arg);
         } catch (AccessControlException ex) {
             return false;
+        }
+    }
+
+    public static Integer getSystemInteger(String arg) {
+        try {
+            return Integer.getInteger(arg);
+        } catch (SecurityException ex) {
+            return null;
         }
     }
 

--- a/src/main/java/com/sun/xml/messaging/saaj/util/SAAJUtil.java
+++ b/src/main/java/com/sun/xml/messaging/saaj/util/SAAJUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at


### PR DESCRIPTION
This pull-request fixes several issues.

---
#77 Specially crafted SWA request can take down server with OOM:
- fixed in 441cdd3
- can set `saaj.mime.soapBodyPartSizeLimit` system property to the max allowed size of the soapMessagePart to prevent maliciously crafted messages to take down the server with `OutOfMemoryError`

---
Parser-pool "leak", discussed in #73 Make EnvelopeFactory ParserPool capacity configurable:
- fixed in bcb3cd8
- this is a little bit involved, but the essence is that this change ensure that the parser is always returned to the pool which it was taken from. It is not guarantied that when the `finally`-block called [`parserPool.get()`](https://github.com/eclipse-ee4j/metro-saaj/commit/6b49c399e0555242061ae65d7e6d7661de500d4d#diff-88d14e9fc36ba00d46d1e9eb1781e055L189) that it would get the same pool from the `ContextClassloaderLocal` which the parser was acquired from, because they are cached in a `WeakHashMap`, which may have been GC-ed between the time the parser was taken, and later returned. The change keeps the reference to the `ParserPool` in scope to also be used to return the parser. This particular problem with `ContextClassloaderLocal` is mentioned in https://github.com/eclipse-ee4j/metro-saaj/issues/73#issuecomment-424014253


---
Re b3bc03e, I am not sure how the `glassfish-copyright-maven-plugin` works, but it would not let the build pass unless we changed some years in some of the changed files' copyright notices, strangely to 2014, which seems a bit odd. The cherry-picked commits were originally from 2014. Maybe the plugin only regard the latest commit in the commit graph as to resolve which year should be in the copyright notice?

---
Originally we had to release our own patched version of SAAJ in 2014 to not be affected by this issues in production. To be able to use the latest version of SAAJ we had to include these fixes in a new internal release based on v1.5.1. This has now run in our production environment with a relatively substantial load, and no problems, for about a month. I hope this can be contributed back to the official repository.