### PR TITLE
#78: test that Requesting a fault reason text in another Locale does not return null

### DIFF
--- a/saaj-ri/src/test/java/soap12/SOAPFaultTests.java
+++ b/saaj-ri/src/test/java/soap12/SOAPFaultTests.java
@@ -63,6 +63,9 @@ public class SOAPFaultTests extends TestCase {
         String englishText = fault.getFaultReasonText(Locale.US);
         assertNotNull(englishText);
         assertEquals("The reason text is as expected", englishText, "Processing error");
+        String czechText = fault.getFaultReasonText(Locale.forLanguageTag("cs"));
+        assertNotNull(czechText);
+        assertEquals("The reason text is as expected", czechText, "Chyba zpracování");
         Iterator locales = fault.getFaultReasonLocales();
         Iterator texts = fault.getFaultReasonTexts();
         assertTrue(locales.hasNext() && texts.hasNext());

--- a/saaj-ri/src/test/resources/soap12/data/fault.xml
+++ b/saaj-ri/src/test/resources/soap12/data/fault.xml
@@ -23,7 +23,7 @@
     </env:Code>
     <env:Reason>
      <env:Text xml:lang="en-US">Processing error</env:Text>
-     <env:Text xml:lang="cs">Chyba zpracov?n?</env:Text>
+     <env:Text xml:lang="cs">Chyba zpracování</env:Text>
     </env:Reason>
     <env:Detail>
      <e:myFaultDetails xmlns:e="http://travelcompany.example.org/faults">


### PR DESCRIPTION
fixes #78 
Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>