### PR TITLE
Bug 165 - Document owner is inconsistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ target/
 *.ipr
 .idea
 .DS_Store
+.settings
+.classpath
+.project

--- a/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/SOAPDocumentImpl.java
+++ b/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/SOAPDocumentImpl.java
@@ -66,12 +66,16 @@ public class SOAPDocumentImpl implements SOAPDocument, jakarta.xml.soap.Node, Do
     private Document document;
 
     public SOAPDocumentImpl(SOAPPartImpl enclosingDocument) {
-        document = createDocument();
+        this(enclosingDocument, createDocument());
+    }
+
+    SOAPDocumentImpl(SOAPPartImpl enclosingDocument, Document document) {
+        this.document = document;
         this.enclosingSOAPPart = enclosingDocument;
         register(this);
     }
 
-    private Document createDocument() {
+    private static Document createDocument() {
         DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance("com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl", SAAJUtil.getSystemClassLoader());
         try {
             final DocumentBuilder documentBuilder = docFactory.newDocumentBuilder();
@@ -442,9 +446,9 @@ public class SOAPDocumentImpl implements SOAPDocument, jakarta.xml.soap.Node, Do
 
     @Override
     public Node cloneNode(boolean deep) {
-        Node node = document.cloneNode(deep);
-        registerChildNodes(node, deep);
-        return findIfPresent(node);
+        SOAPPartImpl enclosingPartClone = (SOAPPartImpl) enclosingSOAPPart.cloneNode(deep);
+        registerChildNodes(enclosingPartClone.getDocument().getDomDocument(), deep);
+        return enclosingPartClone.getDocument();
     }
 
     @Override

--- a/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/SOAPPartImpl.java
+++ b/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/SOAPPartImpl.java
@@ -535,7 +535,7 @@ public abstract class SOAPPartImpl extends SOAPPart implements SOAPDocument {
     @Override
     public org.w3c.dom.Node cloneNode(boolean deep) {
         handleNewSource();
-        return document.cloneNode(deep);
+        return doCloneNode();
     }
     
     protected SOAPPartImpl doCloneNode() {
@@ -544,6 +544,7 @@ public abstract class SOAPPartImpl extends SOAPPart implements SOAPDocument {
         
         newSoapPart.headers = MimeHeadersUtil.copy(this.headers);
         newSoapPart.source = this.source;
+        newSoapPart.document = new SOAPDocumentImpl(newSoapPart, (Document) this.document.getDomDocument().cloneNode(true));
         return newSoapPart;
     }
     

--- a/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/impl/AttrImpl.java
+++ b/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/impl/AttrImpl.java
@@ -1,0 +1,222 @@
+package com.sun.xml.messaging.saaj.soap.impl;
+
+import jakarta.xml.soap.SOAPElement;
+import jakarta.xml.soap.SOAPException;
+import org.w3c.dom.Attr;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.TypeInfo;
+import org.w3c.dom.UserDataHandler;
+
+public class AttrImpl implements Attr, jakarta.xml.soap.Node {
+
+    private SOAPElement soapElement;
+
+    final Attr delegate;
+
+    AttrImpl(SOAPElement element, Attr attr) {
+        this.soapElement = element;
+        this.delegate = attr;
+    }
+
+    public String getNodeName() {
+        return delegate.getNodeName();
+    }
+
+    public String getNodeValue() throws DOMException {
+        return delegate.getNodeValue();
+    }
+
+    public void setNodeValue(String nodeValue) throws DOMException {
+        delegate.setNodeValue(nodeValue);
+    }
+
+    public short getNodeType() {
+        return delegate.getNodeType();
+    }
+
+    public Node getParentNode() {
+        return delegate.getParentNode();
+    }
+
+    public NodeList getChildNodes() {
+        return delegate.getChildNodes();
+    }
+
+    public String getName() {
+        return delegate.getName();
+    }
+
+    public Node getFirstChild() {
+        return delegate.getFirstChild();
+    }
+
+    public boolean getSpecified() {
+        return delegate.getSpecified();
+    }
+
+    public Node getLastChild() {
+        return delegate.getLastChild();
+    }
+
+    public Node getPreviousSibling() {
+        return delegate.getPreviousSibling();
+    }
+
+    public Node getNextSibling() {
+        return delegate.getNextSibling();
+    }
+
+    public String getValue() {
+        return delegate.getValue();
+    }
+
+    public NamedNodeMap getAttributes() {
+        return delegate.getAttributes();
+    }
+
+    public Document getOwnerDocument() {
+        return soapElement.getOwnerDocument();
+    }
+
+    public Node insertBefore(Node newChild, Node refChild) throws DOMException {
+        return delegate.insertBefore(newChild, refChild);
+    }
+
+    public void setValue(String value) throws DOMException {
+        delegate.setValue(value);
+    }
+
+    public Element getOwnerElement() {
+        return soapElement;
+    }
+
+    public TypeInfo getSchemaTypeInfo() {
+        return delegate.getSchemaTypeInfo();
+    }
+
+    public boolean isId() {
+        return delegate.isId();
+    }
+
+    public Node replaceChild(Node newChild, Node oldChild) throws DOMException {
+        return delegate.replaceChild(newChild, oldChild);
+    }
+
+    public Node removeChild(Node oldChild) throws DOMException {
+        return delegate.removeChild(oldChild);
+    }
+
+    public Node appendChild(Node newChild) throws DOMException {
+        return delegate.appendChild(newChild);
+    }
+
+    public boolean hasChildNodes() {
+        return delegate.hasChildNodes();
+    }
+
+    public Node cloneNode(boolean deep) {
+        return delegate.cloneNode(deep);
+    }
+
+    public void normalize() {
+        delegate.normalize();
+    }
+
+    public boolean isSupported(String feature, String version) {
+        return delegate.isSupported(feature, version);
+    }
+
+    public String getNamespaceURI() {
+        return delegate.getNamespaceURI();
+    }
+
+    public String getPrefix() {
+        return delegate.getPrefix();
+    }
+
+    public void setPrefix(String prefix) throws DOMException {
+        delegate.setPrefix(prefix);
+    }
+
+    public String getLocalName() {
+        return delegate.getLocalName();
+    }
+
+    public boolean hasAttributes() {
+        return delegate.hasAttributes();
+    }
+
+    public String getBaseURI() {
+        return delegate.getBaseURI();
+    }
+
+    public short compareDocumentPosition(Node other) throws DOMException {
+        return delegate.compareDocumentPosition(other);
+    }
+
+    public String getTextContent() throws DOMException {
+        return delegate.getTextContent();
+    }
+
+    public void setTextContent(String textContent) throws DOMException {
+        delegate.setTextContent(textContent);
+    }
+
+    public boolean isSameNode(Node other) {
+        return delegate.isSameNode(other);
+    }
+
+    public String lookupPrefix(String namespaceURI) {
+        return delegate.lookupPrefix(namespaceURI);
+    }
+
+    public boolean isDefaultNamespace(String namespaceURI) {
+        return delegate.isDefaultNamespace(namespaceURI);
+    }
+
+    public String lookupNamespaceURI(String prefix) {
+        return delegate.lookupNamespaceURI(prefix);
+    }
+
+    public boolean isEqualNode(Node arg) {
+        return delegate.isEqualNode(arg);
+    }
+
+    public Object getFeature(String feature, String version) {
+        return delegate.getFeature(feature, version);
+    }
+
+    public Object setUserData(String key, Object data, UserDataHandler handler) {
+        return delegate.setUserData(key, data, handler);
+    }
+
+    public Object getUserData(String key) {
+        return delegate.getUserData(key);
+    }
+
+    @Override
+    public void setParentElement(SOAPElement parent) throws SOAPException {
+        this.soapElement = parent;
+    }
+
+    @Override
+    public SOAPElement getParentElement() {
+        return this.soapElement;
+    }
+
+    @Override
+    public void detachNode() {
+        this.soapElement.removeAttributeNode(delegate);
+    }
+
+    @Override
+    public void recycleNode() {
+        detachNode();
+    }
+
+}

--- a/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/impl/CDATAImpl.java
+++ b/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/impl/CDATAImpl.java
@@ -40,6 +40,11 @@ public class CDATAImpl extends TextImpl<CDATASection> implements CDATASection {
     }
 
     @Override
+    protected CDATAImpl doClone() {
+        return new CDATAImpl(getSoapDocument(), this.getTextContent());
+    }
+
+    @Override
     public Text splitText(int offset) throws DOMException {
         Text text = getDomElement().splitText(offset);
         getSoapDocument().registerChildNodes(text, true);

--- a/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/impl/ElementImpl.java
+++ b/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/impl/ElementImpl.java
@@ -10,24 +10,12 @@
 
 package com.sun.xml.messaging.saaj.soap.impl;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.xml.namespace.QName;
-
-import org.w3c.dom.Node;
-
 import com.sun.xml.messaging.saaj.SOAPExceptionImpl;
 import com.sun.xml.messaging.saaj.soap.SOAPDocument;
 import com.sun.xml.messaging.saaj.soap.SOAPDocumentImpl;
 import com.sun.xml.messaging.saaj.soap.name.NameImpl;
 import com.sun.xml.messaging.saaj.util.LogDomainConstants;
 import com.sun.xml.messaging.saaj.util.NamespaceContextIterator;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.NoSuchElementException;
 import jakarta.xml.soap.Name;
 import jakarta.xml.soap.SOAPBodyElement;
 import jakarta.xml.soap.SOAPConstants;
@@ -40,9 +28,21 @@ import org.w3c.dom.Document;
 import org.w3c.dom.DocumentFragment;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.w3c.dom.Text;
 import org.w3c.dom.TypeInfo;
 import org.w3c.dom.UserDataHandler;
+import javax.xml.namespace.QName;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.sun.xml.messaging.saaj.soap.SOAPDocumentImpl.SAAJ_NODE;
 
 public class ElementImpl implements SOAPElement, SOAPBodyElement {
 
@@ -85,6 +85,8 @@ public class ElementImpl implements SOAPElement, SOAPBodyElement {
             }
         }
         element.setAttribute(name, value);
+        Attr attr = element.getAttributeNode(name);
+        register(attr);
     }
 
     @Override
@@ -94,16 +96,21 @@ public class ElementImpl implements SOAPElement, SOAPBodyElement {
 
     @Override
     public Attr getAttributeNode(String name) {
-        return element.getAttributeNode(name);
+        return find(element.getAttributeNode(name));
     }
 
     @Override
     public Attr setAttributeNode(Attr newAttr) throws DOMException {
-        return element.setAttributeNode(newAttr);
+        Attr attr =  element.setAttributeNode(newAttr);
+        register(attr);
+        return attr;
     }
 
     @Override
     public Attr removeAttributeNode(Attr oldAttr) throws DOMException {
+        if (oldAttr instanceof AttrImpl) {
+            oldAttr = ((AttrImpl)oldAttr).delegate;
+        }
         return element.removeAttributeNode(oldAttr);
     }
 
@@ -155,6 +162,10 @@ public class ElementImpl implements SOAPElement, SOAPBodyElement {
         this.soapDocument = ownerDoc;
         this.elementQName = new QName(domElement.getNamespaceURI(), domElement.getLocalName());
         soapDocument.register(this);
+        NamedNodeMap attributes = domElement.getAttributes();
+        for (int i = attributes.getLength() - 1; i >= 0; i--) {
+            register((Attr)attributes.item(i));
+        }
     }
 
     public ElementImpl(
@@ -269,6 +280,17 @@ public class ElementImpl implements SOAPElement, SOAPBodyElement {
     @Override
     public void setTextContent(String textContent) throws DOMException {
         element.setTextContent(textContent);
+        // The text node is always the first child (at least in xerces)
+        Node firstChild = element.getFirstChild();
+        if (firstChild instanceof Text) {
+            // This constructor self-registers the node presence
+            new SOAPTextImpl(soapDocument, textContent) {
+                @Override
+                protected Text createN(SOAPDocumentImpl ownerDoc, String text) {
+                    return (Text) firstChild; // Reuse the text node created by the DOM element
+                }
+            };
+        }
     }
 
     @Override
@@ -592,12 +614,12 @@ public class ElementImpl implements SOAPElement, SOAPBodyElement {
 
         if (isNamespaceQualified(name)) {
             return (SOAPElement)
-                getOwnerDocument().createElementNS(
+                getSoapDocument().createElementNS(
                                        name.getURI(),
                                        name.getQualifiedName());
         } else {
             return (SOAPElement)
-                getOwnerDocument().createElement(name.getQualifiedName());
+                getSoapDocument().createElement(name.getQualifiedName());
         }
     }
 
@@ -605,12 +627,12 @@ public class ElementImpl implements SOAPElement, SOAPBodyElement {
 
         if (isNamespaceQualified(name)) {
             return (SOAPElement)
-                getOwnerDocument().createElementNS(
+                getSoapDocument().createElementNS(
                                        name.getNamespaceURI(),
                                        getQualifiedName(name));
         } else {
             return (SOAPElement)
-                getOwnerDocument().createElement(getQualifiedName(name));
+                getSoapDocument().createElement(getQualifiedName(name));
         }
     }
 
@@ -1567,6 +1589,9 @@ public class ElementImpl implements SOAPElement, SOAPBodyElement {
     @Override
     public void setAttributeNS(
         String namespaceURI,String qualifiedName, String value) {
+        if (namespaceURI != null && namespaceURI.isEmpty()) {
+            namespaceURI = null;
+        }
         int index = qualifiedName.indexOf(':');
         String localName;
         if (index < 0)
@@ -1600,7 +1625,8 @@ public class ElementImpl implements SOAPElement, SOAPBodyElement {
                 setIdAttributeNS(namespaceURI,localName,true);
             }
         }
-                                                                                                                               
+        Attr attr = element.getAttributeNodeNS(namespaceURI, localName);
+        register(attr);
     }
 
     @Override
@@ -1610,12 +1636,28 @@ public class ElementImpl implements SOAPElement, SOAPBodyElement {
 
     @Override
     public Attr getAttributeNodeNS(String namespaceURI, String localName) throws DOMException {
-        return element.getAttributeNodeNS(namespaceURI, localName);
+        return find(element.getAttributeNodeNS(namespaceURI, localName));
     }
 
     @Override
     public Attr setAttributeNodeNS(Attr newAttr) throws DOMException {
         return element.setAttributeNodeNS(newAttr);
+    }
+    
+    private void register(Attr newAttr) {
+        if (newAttr != null) {
+            newAttr.setUserData(SAAJ_NODE, new AttrImpl(this, newAttr), null);
+        }
+    }
+    
+    private Attr find(Attr attr) {
+        if (attr != null) {
+            Object soapAttr = attr.getUserData(SAAJ_NODE);
+            if (soapAttr instanceof Attr) {
+                return (Attr) soapAttr;
+            }
+        }
+        return attr;
     }
 
     @Override

--- a/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/impl/NamedNodeMapImpl.java
+++ b/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/impl/NamedNodeMapImpl.java
@@ -58,7 +58,7 @@ public class NamedNodeMapImpl implements NamedNodeMap {
 
     @Override
     public Node item(int index) {
-        return namedNodeMap.item(index);
+        return soapDocument.findIfPresent(namedNodeMap.item(index));
     }
 
     @Override
@@ -68,7 +68,7 @@ public class NamedNodeMapImpl implements NamedNodeMap {
 
     @Override
     public Node getNamedItemNS(String namespaceURI, String localName) throws DOMException {
-        return namedNodeMap.getNamedItemNS(namespaceURI, localName);
+        return soapDocument.findIfPresent(namedNodeMap.getNamedItemNS(namespaceURI, localName));
     }
 
     @Override

--- a/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/impl/NodeListImpl.java
+++ b/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/impl/NodeListImpl.java
@@ -16,6 +16,8 @@ import org.w3c.dom.NodeList;
 
 import java.util.Objects;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Node list wrapper, finding SOAP elements automatically when possible.
  *
@@ -28,10 +30,8 @@ public class NodeListImpl implements NodeList {
     private final NodeList nodeList;
 
     public NodeListImpl(SOAPDocumentImpl soapDocument, NodeList nodeList) {
-        Objects.requireNonNull(soapDocument);
-        Objects.requireNonNull(soapDocument);
-        this.soapDocument = soapDocument;
-        this.nodeList = nodeList;
+        this.soapDocument = requireNonNull(soapDocument);
+        this.nodeList = requireNonNull(nodeList);
     }
 
     @Override

--- a/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/impl/SOAPCommentImpl.java
+++ b/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/impl/SOAPCommentImpl.java
@@ -39,6 +39,11 @@ public class SOAPCommentImpl extends TextImpl<Comment> implements Comment {
     }
 
     @Override
+    protected SOAPCommentImpl doClone() {
+        return new SOAPCommentImpl(getSoapDocument(), this.getTextContent());
+    }
+
+    @Override
     public boolean isComment() {
         return true;
     }

--- a/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/impl/SOAPTextImpl.java
+++ b/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/impl/SOAPTextImpl.java
@@ -26,6 +26,11 @@ public class SOAPTextImpl extends TextImpl<Text> implements Text {
     }
 
     @Override
+    protected SOAPTextImpl doClone() {
+        return new SOAPTextImpl(getSoapDocument(), this.getTextContent());
+    }
+
+    @Override
     protected Text createN(SOAPDocumentImpl ownerDoc, String text) {
         return ownerDoc.getDomDocument().createTextNode(text);
     }

--- a/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/impl/TextImpl.java
+++ b/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/impl/TextImpl.java
@@ -54,6 +54,8 @@ public abstract class TextImpl<T extends CharacterData> implements Text, Charact
 
     protected abstract T createN(SOAPDocumentImpl ownerDoc, String text);
 
+    protected abstract TextImpl<T> doClone();
+
     public T getDomElement() {
         return domNode;
     }
@@ -186,7 +188,7 @@ public abstract class TextImpl<T extends CharacterData> implements Text, Charact
 
     @Override
     public Node cloneNode(boolean deep) {
-        return domNode.cloneNode(deep);
+        return doClone();
     }
 
     @Override

--- a/saaj-ri/src/test/java/soap/DocumentOwnerTest.java
+++ b/saaj-ri/src/test/java/soap/DocumentOwnerTest.java
@@ -1,0 +1,84 @@
+package soap;
+
+import java.io.InputStream;
+import com.sun.xml.messaging.saaj.soap.SOAPDocumentImpl;
+import com.sun.xml.messaging.saaj.soap.impl.AttrImpl;
+import com.sun.xml.messaging.saaj.soap.impl.SOAPTextImpl;
+import jakarta.xml.soap.MessageFactory;
+import jakarta.xml.soap.SOAPEnvelope;
+import jakarta.xml.soap.SOAPPart;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import junit.framework.TestCase;
+import org.w3c.dom.Node;
+
+/**
+ * Original source taken from https://github.com/coheigea/testcases/tree/master/misc/saaj
+ *
+ * Verifies issue #165
+ */
+public class DocumentOwnerTest extends TestCase {
+
+    /**
+     * Reproduces the issue identified in #165
+     */
+    public void testOwnerDocumentConsistency() throws Exception {
+        Document signedDocument = read("signed-document.xml");
+
+        Element refElement = (Element) signedDocument.getElementsByTagNameNS("http://www.w3.org/2000/09/xmldsig#", "Reference").item(0);
+
+        Attr uriAttr = refElement.getAttributeNodeNS(null, "URI");
+        Document uriOwnerDocument = uriAttr.getOwnerDocument();
+        Document refOwnerDocument = refElement.getOwnerDocument();
+
+        assertSame("Inconsistent document",  refOwnerDocument, uriOwnerDocument);
+        assertEquals("Unexpected document type", SOAPDocumentImpl.class, uriOwnerDocument.getClass());
+    }
+
+    /**
+     * Tests further issues identified as part of the fix for #165. When SAAJ was decoupled from Xerces it seems to have
+     * introduced several problems - notably, cloning of some SAAJ elements results in raw Xerces nodes. This results
+     * in functions within Apache Santuario (canonicalization of documents) and within DSig to produce incorrect
+     * outcomes or fail entirely.
+     */
+    public void testClonePreservesSoapElements() throws Exception {
+        SOAPPart document = read("signed-document.xml");
+        Element signature = (Element) document.getEnvelope().getChildNodes().item(1);
+        Element signedInfo = getElement(signature, "ds:SignedInfo");
+        Element canonicalizationMethod = getElement(signedInfo, "ds:CanonicalizationMethod");
+        Node canonicalizationAttr = canonicalizationMethod.getAttributes().item(0);
+        Node digestValue = getElement(getElement(signedInfo, "ds:Reference"), "ds:DigestValue")
+                .getFirstChild();
+
+        assertEquals(AttrImpl.class, canonicalizationAttr.getClass());
+        assertEquals(SOAPTextImpl.class, digestValue.getClass());
+
+        Document clonedDocument = (Document) document.getOwnerDocument().cloneNode(true);
+        assertEquals(SOAPDocumentImpl.class, clonedDocument.getClass());
+
+        Node clonedEnvelope = clonedDocument.getElementsByTagName("SOAP-ENV:Envelope").item(0);
+        assertTrue(SOAPEnvelope.class.isAssignableFrom(clonedEnvelope.getClass()));
+
+        Element clonedSignature = (Element) ((SOAPEnvelope)clonedEnvelope).getChildNodes().item(1);
+        Element clonedSignedInfo = getElement(clonedSignature, "ds:SignedInfo");
+        Element clonedCanonicalizationMethod = getElement(clonedSignedInfo, "ds:CanonicalizationMethod");
+        Node clonedCanonicalizationAttr = clonedCanonicalizationMethod.getAttributes().item(0);
+        Node clonedDigestValue = getElement(getElement(clonedSignedInfo, "ds:Reference"), "ds:DigestValue")
+                .getFirstChild();
+
+        assertEquals(AttrImpl.class, clonedCanonicalizationAttr.getClass());
+        assertEquals(SOAPTextImpl.class, clonedDigestValue.getClass());
+    }
+
+    private Element getElement(Element parent, String name) {
+        return (Element)parent.getElementsByTagName(name).item(0);
+    }
+
+    private static SOAPPart read(String file) throws Exception {
+        try (InputStream in = DocumentOwnerTest.class.getResource(file).openStream()) {
+            return MessageFactory.newInstance().createMessage(null, in).getSOAPPart();
+        }
+    }
+}

--- a/saaj-ri/src/test/resources/soap/signed-document.xml
+++ b/saaj-ri/src/test/resources/soap/signed-document.xml
@@ -1,0 +1,33 @@
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><SOAP-ENV:Body><add xmlns="http://ws.apache.org/counter/counter_port_type"><value xmlns="">15</value></add></SOAP-ENV:Body><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    <ds:SignedInfo>
+        <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"></ds:CanonicalizationMethod>
+        <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"></ds:SignatureMethod>
+        <ds:Reference URI="">
+            <ds:Transforms>
+                <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"></ds:Transform>
+                <ds:Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments"></ds:Transform>
+            </ds:Transforms>
+            <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"></ds:DigestMethod>
+            <ds:DigestValue>utykt34p7zuu7K6QJyJugFH4kruKiJEUPRZO/xdCSRM=</ds:DigestValue>
+        </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>
+        qlNZviAjBrKXCoRGx3bjRE+0MrSEJ/feTFHdmU8CMYX26C2xQDvImb67mCV3201NXuDkf2Vcyuhj&#xD;
+        LNESGhC7yN85nBZiBd2AuAsDc+7gIPX9cEyp6uEkt2sK+txL0UxjMtyzb++DEhzVqG8OTizcbCun&#xD;
+        1Na5oJEwYWoKk6JhzJxv92GT32M2Xlh0sO2TnNv7KQd7ldW+TWSQ43hki9IjmLZNej2Zosq3W/ch&#xD;
+        HD5unlRAJQUSAEl+A33O+rMoi0SXGOYPlKxJYRi6YjUNI0S5eRPwSFHqnhtU1NqTcOfuY4TRVRfr&#xD;
+        BuURmSsnVmQ1CZdChqtM6NZBqP1Kv9tt9PKk8w==
+    </ds:SignatureValue>
+    <ds:KeyInfo>
+        <ds:KeyValue>
+            <ds:RSAKeyValue>
+                <ds:Modulus>vsCIQ4bzB4LLfBGu6i1eIxzlk+GvCTHhdwZVRu2sq+Fx/HlHmXtNz+AOtOYiQjaM1CEXVQ1WLnpi&#xD;
+                    NRjR/jNR2AjBl0Nf4+CQLBZKyMU+x3sdfonz4Vom0c6SK6rAz8rMRLTazxXZvAYUQch72SqKoNRi&#xD;
+                    ttH6dIlIT+/nqTa+MhMOGtxstK/dH1R5mGWM6ueZeqHUV4H6uW8A/4KDy1nrPT4EbMJAZxTXLGCy&#xD;
+                    b/uLTaBzZlOhqNleKvtuL+rr/eOcvlmrWAm5Sgx4YcPe7pWy1Qa24FkdiDkH3tXWVopS9zk9F5Fn&#xD;
+                    1M21FjwgjfPHpNt7VxK4GJvrpkkHtxsfRirnEQ==</ds:Modulus>
+                <ds:Exponent>AQAB</ds:Exponent>
+            </ds:RSAKeyValue>
+        </ds:KeyValue>
+    </ds:KeyInfo>
+</ds:Signature></SOAP-ENV:Envelope>


### PR DESCRIPTION
This change fixes the delegation so that element types, including attributes and text nodes, correctly identify as being part of the same owning document.

Note that whilst this fixes the consistency of some cloned elements, a comprehensive fix of cloning is beyond what can be achieved within this change and requires a broader review.