### PR TITLE
prevent java.lang.StringIndexOutOfBoundsException

### DIFF
--- a/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/impl/CDATAImpl.java
+++ b/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/impl/CDATAImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -20,6 +20,7 @@ public class CDATAImpl extends TextImpl<CDATASection> implements CDATASection {
 
     static final String cdataUC = "<![CDATA[";
     static final String cdataLC = "<![cdata[";
+    static final String CDATA_CLOSE = "]]>";
 
     public CDATAImpl(SOAPDocumentImpl ownerDoc, String text) {
         super(ownerDoc, text);

--- a/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/impl/ElementImpl.java
+++ b/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/soap/impl/ElementImpl.java
@@ -677,10 +677,11 @@ public class ElementImpl implements SOAPElement, SOAPBodyElement {
     
     @Override
     public SOAPElement addTextNode(String text) throws SOAPException {
-        if (text.startsWith(CDATAImpl.cdataUC)
-            || text.startsWith(CDATAImpl.cdataLC))
+        if ((text.startsWith(CDATAImpl.cdataUC) || text.startsWith(CDATAImpl.cdataLC))
+            && text.endsWith(CDATAImpl.CDATA_CLOSE))
             return addCDATA(
-                text.substring(CDATAImpl.cdataUC.length(), text.length() - 3));
+                text.substring(CDATAImpl.cdataUC.length(), 
+                text.length() - CDATAImpl.CDATA_CLOSE.length()));
         return addText(text);
     }
 

--- a/saaj-ri/src/test/java/element/ElementTest.java
+++ b/saaj-ri/src/test/java/element/ElementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -163,6 +163,22 @@ public class ElementTest extends TestCase {
         String returnedText = element.getValue();
 
         assertEquals(originalText, returnedText);
+
+        element.removeContents();
+        element.addTextNode("<![CDATA[");
+        assertEquals("<![CDATA[", element.getValue());
+
+        element.removeContents();
+        element.addTextNode("]]>");
+        assertEquals("]]>", element.getValue());
+
+        element.removeContents();
+        element.addTextNode("<![cdata[]]>");
+        assertNull(element.getValue());
+
+        element.removeContents();
+        element.addTextNode("<![cdata[test]]>");
+        assertEquals("test", element.getValue());
     }
 
     public void testAddChildElement() throws Exception {


### PR DESCRIPTION
... when text starts with `<![CDATA[` but does not end with `]]>`. This also allows to add `<![CDATA[` as text content.

fixes #133