### PR TITLE
System property to force default transformer factory

### DIFF
--- a/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/util/transform/EfficientStreamingTransformer.java
+++ b/saaj-ri/src/main/java/com/sun/xml/messaging/saaj/util/transform/EfficientStreamingTransformer.java
@@ -27,6 +27,7 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
 import com.sun.xml.messaging.saaj.util.LogDomainConstants;
+import com.sun.xml.messaging.saaj.util.SAAJUtil;
 import org.w3c.dom.Document;
 
 import com.sun.xml.messaging.saaj.util.XMLDeclarationParser;
@@ -77,7 +78,8 @@ public class EfficientStreamingTransformer extends Transformer {
     
     private EfficientStreamingTransformer() {
         boolean log = LOG.compareAndSet(true, false);
-        TransformerFactory tf = TransformerFactory.newInstance();
+        boolean useDefaultTransformerFactory = SAAJUtil.getSystemBoolean("saaj.use.default.transformer.factory");
+        TransformerFactory tf = useDefaultTransformerFactory ? TransformerFactory.newDefaultInstance() : TransformerFactory.newInstance();
         try {
             tf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         } catch (TransformerConfigurationException e) {

--- a/saaj-ri/src/main/java/module-info.java
+++ b/saaj-ri/src/main/java/module-info.java
@@ -146,6 +146,15 @@
  * large attachments in incoming messages. The default is false.</td>
  * </tr>
  *
+ * <tr>
+ *  <td><a id="saaj.use.default.transformer.factory">saaj.use.default.transformer.factory</a></td>
+ *  <td>boolean</td>
+ *  <td>The {@code saaj.use.default.transformer.factory} property forces usage of
+ *  the {@code TransformerFactory} builtin system-default implementation instead of the
+ *  <a href="https://docs.oracle.com/en/java/javase/21/docs/api/java.xml/module-summary.html#LookupMechanism">JAXP Lookup Mechanism</a>.
+ *  The default is false.</td>
+ * </tr>
+ *
  * </table>
  *
  * @see <a href="https://jakarta.ee/specifications/soap-attachments">Jakarta SOAP Specification</a>


### PR DESCRIPTION
The saaj.use.default.transformer.factory system property to force usage of the TransformerFactory builtin system-default implementation