### PR TITLE
Updated dependencies

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation
+# Copyright (c) 2021, 2026 Contributors to the Eclipse Foundation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -41,7 +41,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:
-        distribution: 'zulu'
+        distribution: 'temurin'
         java-version: ${{ matrix.java_version }}
         cache: maven
     - name: Verify

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,4 +45,4 @@ jobs:
         java-version: ${{ matrix.java_version }}
         cache: maven
     - name: Verify
-      run: mvn -B -V -U -C -Poss-release clean verify -Dgpg.skip=true -Doss.disallow.snapshots=false org.glassfish.copyright:glassfish-copyright-maven-plugin:check -Dcopyright.ignoreyear=true
+      run: mvn -B -V -U -C -Poss-release clean verify -Dgpg.skip=true org.glassfish.copyright:glassfish-copyright-maven-plugin:check -Dcopyright.ignoreyear=true

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation
+# Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -44,7 +44,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '21'
           cache: maven
       - name: Add static content

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <spotbugs.skip>false</spotbugs.skip>
         <spotbugs.threshold>Low</spotbugs.threshold>
         <spotbugs.version>4.9.8.3</spotbugs.version>
-        <findsecbugs.version>1.11.0</findsecbugs.version>
+        <findsecbugs.version>1.14.0</findsecbugs.version>
 
         <maven.compiler.release>11</maven.compiler.release>
         <maven.compiler.testRelease>${maven.compiler.release}</maven.compiler.testRelease>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <xml.soap-api.version>3.0.2</xml.soap-api.version>
 
         <fastinfoset.version>2.1.1</fastinfoset.version>
-        <mimepull.version>1.10.0</mimepull.version>
+        <mimepull.version>1.11.0</mimepull.version>
         <stax-ex.version>2.1.0</stax-ex.version>
         <junit.version>4.13.2</junit.version>
         <saaj.version>${project.version}</saaj.version>

--- a/pom.xml
+++ b/pom.xml
@@ -11,13 +11,13 @@
 -->
 
 <!-- steps to release give all of them together in one command : mvn release:clean release:prepare release:perform -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" child.project.url.inherit.append.path="false">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.2</version>
         <relativePath/>
     </parent>
 
@@ -27,11 +27,9 @@
     <packaging>pom</packaging>
 
     <name>Jakarta SOAP</name>
-    <description>
-        Implementation of Jakarta SOAP with Attachments Specification
-    </description>
+    <description>Implementation of Jakarta SOAP with Attachments Specification</description>
 
-    <scm>
+    <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
         <connection>scm:git:git@github.com:eclipse-ee4j/metro-saaj.git</connection>
         <developerConnection>scm:git:git@github.com:eclipse-ee4j/metro-saaj.git</developerConnection>
         <url>https://github.com/eclipse-ee4j/metro-saaj</url>
@@ -48,15 +46,20 @@
 
     <developers>
         <developer>
-            <id>lukasj</id>
-            <name>Lukas Jungmann</name>
-            <email>Lukas.Jungmann@oracle.com</email>
-        </developer>
-        <developer>
-            <id>bravehorsie</id>
-            <name>Roman Grigoriadi</name>
+            <id>eclipse-metro-dev</id>
+            <name>Metro Development Team</name>
+            <email>metro-dev@eclipse.org</email>
+            <organization>Eclipse Foundation</organization>
+            <organizationUrl>https://www.eclipse.org</organizationUrl>
+            <url>https://projects.eclipse.org/projects/ee4j.metro/who</url>
         </developer>
     </developers>
+    <contributors>
+        <contributor>
+            <name>GihHub Contributors</name>
+            <url>https://github.com/eclipse-ee4j/metro-saaj/graphs/contributors</url>
+        </contributor>
+    </contributors>
 
     <issueManagement>
         <system>IssueTracker</system>
@@ -458,31 +461,6 @@ Copyright &#169; 2018, ${current.year} Eclipse Foundation. All rights reserved.]
                 <release.autoPublish>false</release.autoPublish>
                 <release.waitUntil>published</release.waitUntil>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.cyclonedx</groupId>
-                        <artifactId>cyclonedx-maven-plugin</artifactId>
-                        <configuration>
-                            <!-- Without this it doesn't generate cyclonedx files at all. -->
-                            <skipNotDeployed>false</skipNotDeployed>
-                        </configuration>
-                    </plugin>
-                    <!-- We have to override settings from parent -->
-                    <plugin>
-                        <groupId>org.sonatype.central</groupId>
-                        <artifactId>central-publishing-maven-plugin</artifactId>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <autoPublish>${release.autoPublish}</autoPublish>
-                            <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots</centralSnapshotsUrl>
-                            <deploymentName>${release.projectName} ${project.version}</deploymentName>
-                            <publishingServerId>central</publishingServerId>
-                            <waitUntil>${release.waitUntil}</waitUntil>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <spotbugs.exclude>${project.build.commonResourcesDirectory}/config/exclude.xml</spotbugs.exclude>
         <spotbugs.skip>false</spotbugs.skip>
         <spotbugs.threshold>Low</spotbugs.threshold>
-        <spotbugs.version>4.8.3.1</spotbugs.version>
+        <spotbugs.version>4.9.8.3</spotbugs.version>
         <findsecbugs.version>1.11.0</findsecbugs.version>
 
         <maven.compiler.release>11</maven.compiler.release>
@@ -125,20 +125,20 @@ Copyright &#169; 2018, ${current.year} Eclipse Foundation. All rights reserved.]
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>buildnumber-maven-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.6.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.12.1</version>
+                    <version>3.15.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.copyright</groupId>
@@ -160,12 +160,12 @@ Copyright &#169; 2018, ${current.year} Eclipse Foundation. All rights reserved.]
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.5</version>
+                    <version>3.5.5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>5.1.9</version>
+                    <version>6.0.2</version>
                     <configuration>
                         <niceManifest>true</niceManifest>
                         <instructions>
@@ -175,35 +175,35 @@ Copyright &#169; 2018, ${current.year} Eclipse Foundation. All rights reserved.]
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.6.3</version>
+                    <version>3.12.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.6.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.4</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>3.2.5</version>
+                    <version>3.5.5</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.8.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.6.1</version>
+                    <version>3.10.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-antrun-plugin</artifactId>
@@ -224,10 +224,10 @@ Copyright &#169; 2018, ${current.year} Eclipse Foundation. All rights reserved.]
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[11,)</version>
+                                    <version>[17,)</version>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
-                                    <version>[3.6.0,)</version>
+                                    <version>[3.9.0,)</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>
@@ -347,7 +347,7 @@ Copyright &#169; 2018, ${current.year} Eclipse Foundation. All rights reserved.]
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>12.2.0</version>
+                <version>12.2.1</version>
                 <configuration>
                     <failBuildOnCVSS>7</failBuildOnCVSS>
                     <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>

--- a/saaj-ri/pom.xml
+++ b/saaj-ri/pom.xml
@@ -228,7 +228,7 @@
                         <plugin>
                             <groupId>org.jacoco</groupId>
                             <artifactId>jacoco-maven-plugin</artifactId>
-                            <version>0.8.11</version>
+                            <version>0.8.14</version>
                         </plugin>
                     </plugins>
                 </pluginManagement>


### PR DESCRIPTION
- Parent 2.0.2 configures CycloneDX properly now
- scm defaults caused incorrect paths on Maven Central in submodules
- Updated information about developers and contributors - not hardcoded details, rather links to pages which collect current useful information.
- Now we need JDK17+ for compilation, but everything still should work fine with JDK11 too.
  - Higher priority have latest LTS versions and security, however we don't drop support for JDK11 yet as it is not required at this moment.
  - Switched workflows from JDK Zulu to Temurin, they already used JDK21
